### PR TITLE
Enable spell checking on Team Explorer commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,4 @@ ModelManifest.xml
 
 # VSIX signing
 sign.bat
+/.vs/

--- a/CommitFormatter.Core/FormatterSettings.cs
+++ b/CommitFormatter.Core/FormatterSettings.cs
@@ -29,6 +29,7 @@ namespace Adrup.CommitFormatter.Core
         public const string FontSizeKey = "FontSize";
         public const string UseMonospacedFontKey = "UseMonospacedFont";
         public const string BlankSecondLineKey = "BlankSecondLine";
+        public const string EnableSpellCheckKey = "EnableSpellCheck";
 
         private WritableSettingsStore _userSettingsStore;
 
@@ -75,6 +76,12 @@ namespace Adrup.CommitFormatter.Core
         {
             get { return _userSettingsStore.GetBoolean(CollectionPath, BlankSecondLineKey, true); }
             set { _userSettingsStore.SetBoolean(CollectionPath, BlankSecondLineKey, value); }
+        }
+
+        public bool EnableSpellCheck
+        {
+            get { return _userSettingsStore.GetBoolean(CollectionPath, EnableSpellCheckKey, true); }
+            set { _userSettingsStore.SetBoolean(CollectionPath, EnableSpellCheckKey, value); }
         }
     }
 }

--- a/CommitFormatter.TeamFoundation.14.0/FormatterSection.cs
+++ b/CommitFormatter.TeamFoundation.14.0/FormatterSection.cs
@@ -40,6 +40,7 @@ namespace Adrup.CommitFormatter.TeamFoundation
         private int _fontSize;
         private bool _useMonospacedFont;
         private bool _blankSecondLine;
+        private bool _enableSpellCheck;
 
         private TextBox _commitMessageBox = null;
         private LabeledTextBox _labeledTextBox = null;
@@ -61,6 +62,7 @@ namespace Adrup.CommitFormatter.TeamFoundation
             _fontSize = settings.FontSize;
             _useMonospacedFont = settings.UseMonospacedFont;
             _blankSecondLine = settings.BlankSecondLine;
+            _enableSpellCheck = settings.EnableSpellCheck;
         }
 
         public override void Loaded(object sender, SectionLoadedEventArgs e)
@@ -109,6 +111,7 @@ namespace Adrup.CommitFormatter.TeamFoundation
 
             _commitMessageBox.TextChanged += OnCommitMessageChanged;
             _commitMessageBox.SelectionChanged += OnSelectionChanged;
+            _commitMessageBox.SpellCheck.IsEnabled = _enableSpellCheck;
 
             if (_useMonospacedFont)
                 _commitMessageBox.FontFamily = new FontFamily("Consolas");

--- a/CommitFormatter.TeamFoundation.14.0/SettingsSection.cs
+++ b/CommitFormatter.TeamFoundation.14.0/SettingsSection.cs
@@ -46,6 +46,7 @@ namespace Adrup.CommitFormatter.TeamFoundation
             view.txtFontSize.Text = _settings.FontSize.ToString();
             view.chkUseMonospacedFont.IsChecked = _settings.UseMonospacedFont;
             view.chkBlankSecondLine.IsChecked = _settings.BlankSecondLine;
+            view.chkEnableSpellCheck.IsChecked = _settings.EnableSpellCheck;
         }
 
         public override void SaveContext(object sender, SectionSaveContextEventArgs e)
@@ -58,6 +59,7 @@ namespace Adrup.CommitFormatter.TeamFoundation
             if (int.TryParse(view.txtFontSize.Text, out value)) _settings.FontSize = value;
             _settings.UseMonospacedFont = view.chkUseMonospacedFont.IsChecked.Value;
             _settings.BlankSecondLine = view.chkBlankSecondLine.IsChecked.Value;
+            _settings.EnableSpellCheck = view.chkEnableSpellCheck.IsChecked.Value;
         }
 
     }

--- a/CommitFormatter.TeamFoundation.14.0/SettingsSectionView.xaml
+++ b/CommitFormatter.TeamFoundation.14.0/SettingsSectionView.xaml
@@ -20,6 +20,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
@@ -34,6 +35,8 @@
         <CheckBox Name="chkBlankSecondLine"  Grid.Row="3" Margin="0,0,0,6" Background="{StaticResource ToolWindowBackgroundBrushKey}">Blank Second Line</CheckBox>
 
         <CheckBox Name="chkUseMonospacedFont"  Grid.Row="4" Margin="0,0,0,6" Background="{StaticResource ToolWindowBackgroundBrushKey}">Use Monospaced Font</CheckBox>
+
+        <CheckBox Name="chkEnableSpellCheck"  Grid.Row="5" Margin="0,0,0,6" Background="{StaticResource ToolWindowBackgroundBrushKey}">Enable Spell Check</CheckBox>
 
     </Grid>
 </UserControl>


### PR DESCRIPTION
- Set `SpellCheck.IsEnabled = true` on the commit `MessageBox`.
- Add `Enable Spell Check` option to settings